### PR TITLE
Feat: Add hero/landing page section to homepage

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,99 +1,3 @@
-// import React, { useEffect, useState } from "react";
-// import axios from "axios";
-// import Spinner from "../component/Spinner";
-// import { Link } from "react-router-dom";
-// import { AiOutlineEdit } from "react-icons/ai";
-// import { BsInfoCircle } from "react-icons/bs";
-// import { MdOutlineAddBox, MdOutlineDelete } from "react-icons/md";
-// import BooksTable from '../component/Home/BooksTable';
-// import BooksCard from '../component/Home/BooksCard';
-
-
-// const Home = () => {
-//   const [books, setBooks] = useState([]);
-//   const [loading, setLoading] = useState(false);
-
-//   useEffect(() => {
-//     setLoading(true);
-//     axios
-//       .get("http://localhost:5555/sample")
-//       .then((response) => {
-//         setBooks(response.data.data);
-//         setLoading(false);
-//       })
-//       .catch((error) => {
-//         console.log(error);
-//         setLoading(false);
-//       });
-//   }, []);
-
-//   return (
-//     <div className="p-4">
-//       <div className="flex justify-center items-center gap-x-4">
-//         <h1 className="text-sky-800 text-4xl">Book list</h1>
-//         <Link to="/sample/create">
-//           <MdOutlineAddBox className="text-sky-800 text-4xl" />
-//         </Link>
-//       </div>
-//       {loading ? (
-//         <Spinner />
-//       ) : (
-//         <table className="w-full border-separate border-spacing-2">
-//           <thead>
-//             <tr>
-//               <th className="border border-slate-600 rounded-md">No</th>
-//               <th className="border border-slate-600 rounded-md">Title</th>
-//               <th className="border border-slate-600 rounded-md max-md:hidden">
-//                 Author
-//               </th>
-//               <th className="border border-slate-600 rounded-md max-md:hidden">
-//                 Publish Year
-//               </th>
-//               <th className="border border-slate-600 rounded-md">Operations</th>
-//             </tr>
-//           </thead>
-//           <tbody>
-//             {books.map((book, index) => (
-//               <tr key={book._id} className="h-8">
-//                 <td className="border border-slate-700 rounded-md text-center">
-//                   {index + 1}
-//                 </td>
-//                 <td className="border border-slate-700 rounded-md text-center">
-//                   {book.title}
-//                 </td>
-//                 <td className="border border-slate-700 rounded-md text-center max-md:hidden">
-//                   {book.author}
-//                 </td>
-//                 <td className="border border-slate-700 rounded-md text-center max-md:hidden">
-//                   {book.publishYear}
-//                 </td>
-//                 <td className="border border-slate-700 rounded-md text-center">
-//                   <div className="flex justify-center gap-x-4">
-//                     <Link to={`/sample/show/${book._id}`}>
-//                       <BsInfoCircle className="text-2xl text-green-800" />
-//                     </Link>
-//                     <Link to={`/sample/edit/${book._id}`}>
-//                       <AiOutlineEdit className="text-2xl text-yellow-600" />
-//                     </Link>
-//                     <Link to={`/sample/delete/${book._id}`}>
-//                       <MdOutlineDelete className="text-2xl text-red-600" />
-//                     </Link>
-//                   </div>
-//                 </td>
-//               </tr>
-//             ))}
-//           </tbody>
-//         </table>
-//       )}
-//     </div>
-//   );
-// };
-
-// export default Home;
-
-
-
-
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import Spinner from '../component/Spinner';
@@ -107,7 +11,6 @@ import { host } from '../utils/constant';
 
 const Home = () => {
   const [books, setBooks] = useState([]);
-  console.log("🚀 ~ Home ~ books:", books)
   const [loading, setLoading] = useState(false);
   const [showType, setShowType] = useState('table');
 
@@ -126,34 +29,64 @@ const Home = () => {
   }, []);
 
   return (
-    <div className='p-4'>
-      <div className='flex justify-center items-center gap-x-4'>
-        <button
-          className='bg-sky-300 hover:bg-sky-600 px-4 py-1 rounded-lg'
-          onClick={() => setShowType('table')}
-        >
-          Table
-        </button>
-        <button
-          className='bg-sky-300 hover:bg-sky-600 px-4 py-1 rounded-lg'
-          onClick={() => setShowType('card')}
-        >
-          Card
-        </button>
+    // We remove the default 'p-4' from the main container
+    // to allow the hero section to go full-width
+    <div>
+      {/* --- YOUR NEW PROFESSIONAL HERO SECTION --- */}
+      <section className="bg-gradient-to-r from-sky-700 to-sky-900 text-white shadow-lg">
+        <div className="container mx-auto px-6 py-20 text-center">
+          <h1 className="text-5xl font-bold mb-4 tracking-tight">
+            Welcome to Your Digital Bookshelf
+          </h1>
+          <p className="text-xl text-sky-100 mb-10 max-w-2xl mx-auto">
+            Discover, manage, and track your personal library. Your next great
+            read is just a click away.
+          </p>
+          <a
+            href="#book-list"
+            className="bg-white text-sky-800 font-bold py-3 px-8 rounded-full text-lg 
+                       transition duration-300 ease-in-out transform hover:bg-sky-50 hover:scale-105"
+          >
+            View Your Collection
+          </a>
+        </div>
+      </section>
+
+      {/* --- EXISTING BOOK LIST (I added 'p-4' back here) --- */}
+      <div className="p-4">
+        <div className="flex justify-center items-center gap-x-4 mt-8">
+          <button
+            className="bg-sky-300 hover:bg-sky-600 px-4 py-1 rounded-lg"
+            onClick={() => setShowType('table')}
+          >
+            Table
+          </button>
+          <button
+            className="bg-sky-300 hover:bg-sky-600 px-4 py-1 rounded-lg"
+            onClick={() => setShowType('card')}
+          >
+            Card
+          </button>
+        </div>
+
+        <div className="flex justify-between items-center">
+          {/* This ID allows the button in the hero section to scroll here */}
+          <h1 className="text-3xl my-8" id="book-list">
+            Books List
+          </h1>
+          <Link to="/sample/create">
+            <MdOutlineAddBox className="text-sky-800 text-4xl" />
+          </Link>
+        </div>
+
+        {loading ? (
+          <Spinner />
+        ) : showType === 'table' ? (
+          <BooksTable books={books} />
+        ) : (
+          <BooksCard books={books} />
+        )}
       </div>
-      <div className='flex justify-between items-center'>
-        <h1 className='text-3xl my-8'>Books List</h1>
-        <Link to='/sample/create'>
-          <MdOutlineAddBox className='text-sky-800 text-4xl' />
-        </Link>
-      </div>
-      {loading ? (
-        <Spinner />
-      ) : showType === 'table' ? (
-        <BooksTable books={books} />
-      ) : (
-        <BooksCard books={books} />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
# Short Description
This PR adds a professional hero/landing page section above the book list on the homepage.

# Screenshot of New Section
Here's how the new landing page section looks:

<img width="1919" height="884" alt="image" src="https://github.com/user-attachments/assets/7162cf09-7ec8-4310-9bf9-07f1c879ed36" />

# Points Added Or Removed
* Added a new `<section>` to `Home.jsx` with styled heading, paragraph, and button.
* Added `id="book-list"` to the `<h1>Books List</h1>` tag for the scroll link.
* Adjusted padding on the main `div` and the book list container.

# Links To Issues
Closes #2

# Files Changed
* `src/frontend/pages/Home.jsx`